### PR TITLE
Add missing inline tag

### DIFF
--- a/include/cxxsubs.hpp
+++ b/include/cxxsubs.hpp
@@ -233,7 +233,7 @@ struct set_completions {
 
 // Specialize set completion for Completion Command class
 template <>
-bool set_completions::operator()<CompletionCommand &>(CompletionCommand &t) {
+inline bool set_completions::operator()<CompletionCommand &>(CompletionCommand &t) {
   t.set_verbs_list(verbs_list);
   return true;
 }


### PR DESCRIPTION
When including cxxstubs.hpp from multiple compilation units, the linker complains:
multiple definition of `bool cxxsubs::functors::set_completions::operator()<cxxsubs::CompletionCommand&>(cxxsubs::CompletionCommand&)'
Looks like the root cause is a missing inline tag for the specialization that is no longer a templated function. Fixed it :)